### PR TITLE
fix: avoid minifying identifiers when bundling

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -6,7 +6,8 @@ export default defineBuildConfig({
 	rollup: {
 		emitCJS: true,
 		esbuild: {
-			minify: true,
+			minifySyntax: true,
+			minifyWhitespace: true,
 		},
 	},
 });


### PR DESCRIPTION
Minifying identifiers in a library is bad for debugging and stack traces.
