### PR TITLE
fix: allow `icons` and `sources` together with `sprite.extraIcons`

### DIFF
--- a/src/icon.ts
+++ b/src/icon.ts
@@ -121,7 +121,8 @@ export const getExtraIcons = async (options: Options): Promise<Icon[]> => {
 					);
 				}
 			}
-		} else if (Array.isArray(options.sprite.extraIcons.icons)) {
+		}
+		if (Array.isArray(options.sprite.extraIcons.icons)) {
 			for (const icon of options.sprite.extraIcons.icons) {
 				if (!icon.name || !icon.source)
 					log.error(

--- a/src/icon.ts
+++ b/src/icon.ts
@@ -132,7 +132,7 @@ export const getExtraIcons = async (options: Options): Promise<Icon[]> => {
 					);
 				if (sources.some((source) => source.name === icon.source)) {
 					log.warn(
-						`options.sprite.extraIcons.icons: icon source is already included: ${JSON.stringify(
+						`options.sprite.extraIcons.icons: icons from source '${icon.source}' already included from options.sprite.extraIcons.sources: ${JSON.stringify(
 							icon,
 						)}.`,
 					);

--- a/src/icon.ts
+++ b/src/icon.ts
@@ -130,7 +130,15 @@ export const getExtraIcons = async (options: Options): Promise<Icon[]> => {
 							icon,
 						)}.`,
 					);
-				icons.push(new Icon(icon, options));
+				if (sources.some((source) => source.name === icon.source)) {
+					log.warn(
+						`options.sprite.extraIcons.icons: icon source is already included: ${JSON.stringify(
+							icon,
+						)}.`,
+					);
+				} else {
+					icons.push(new Icon(icon, options));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This patch just removes the `else` from the `sprite.extraIcons` logic so the `icons` and `sources` options function as documented.