### PR TITLE
refactor: remove redundant icon validity check in sprite.extraIcons

### DIFF
--- a/src/icon.ts
+++ b/src/icon.ts
@@ -122,12 +122,6 @@ export const getExtraIcons = async (options: Options): Promise<Icon[]> => {
 		}
 
 		for (const icon of options.sprite.extraIcons.icons) {
-			if (!icon.name || !icon.source)
-				log.error(
-					`options.sprite.extraIcons.icons: Invalid icon: ${JSON.stringify(
-						icon,
-					)}.`,
-				);
 			if (sources.some((source) => source.name === icon.source)) {
 				log.warn(
 					`options.sprite.extraIcons.icons: icons from source '${icon.source}' already included from options.sprite.extraIcons.sources: ${JSON.stringify(


### PR DESCRIPTION
Continuing from #136 